### PR TITLE
Fix outdated script paths in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,11 @@ npdl/
 │   ├── data_loader.py       # Functions for loading simulation data
 │   ├── data_processor.py    # Data processing utilities
 │   └── network_viz.py       # Network visualization components
-├── run_scenario_generator.py # Scenario generation and evaluation
-└── run_sweep_analysis.py    # Complete sweep workflow
+├── scripts/
+│   └── runners/
+│       ├── run_scenario_generator.py    # Scenario generation and evaluation
+│       ├── run_sweep_analysis.py        # Complete sweep workflow
+│       └── run_evolutionary_generator.py # Evolution-based scenario generation
 ```
 
 ## Usage
@@ -83,7 +86,7 @@ For systematic exploration of the parameter space, NPDL includes tools to genera
 #### Basic Random Scenario Generation
 
 ```bash
-python run_sweep_analysis.py [options]
+python scripts/runners/run_sweep_analysis.py [options]
 ```
 
 Options:
@@ -110,7 +113,7 @@ This workflow:
 For more sophisticated scenario discovery, the evolutionary algorithm approach iteratively improves scenarios through selection, crossover, and mutation:
 
 ```bash
-python run_evolutionary_generator.py [options]
+python scripts/runners/run_evolutionary_generator.py [options]
 ```
 
 Options:
@@ -138,18 +141,9 @@ The evolutionary approach offers several advantages:
    - Mutation (random variations to explore new possibilities)
    - Generational improvement tracking
 
-To visualize and analyze the evolutionary process:
-
-```bash
-python -m analysis.evolution_visualizer [options]
-```
-
-This generates a comprehensive evolution report including:
-- Evolution progress across generations
-- Strategy composition changes over time
-- Metric improvements through evolution
-- Comparison of top evolved scenarios
-- Strategy performance analysis
+To visualize and analyze results, inspect the files generated in the
+`evolution_analysis` directory after the run. These include CSV data and
+several plots summarizing progress across generations.
 
 #### Interestingness Metrics
 
@@ -171,7 +165,7 @@ Example output graphs include:
 For more targeted exploration, you can also run only the basic scenario generation step:
 
 ```bash
-python run_scenario_generator.py --num_generate 50 --eval_runs 3 --save_runs 10 --top_n 5
+python scripts/runners/run_scenario_generator.py --num_generate 50 --eval_runs 3 --save_runs 10 --top_n 5
 ```
 
 ### Visualization Dashboard
@@ -459,13 +453,13 @@ pytest --cov=npdl
 python -m npdl.core.test_basic
 
 # Generate and analyze random scenarios
-python run_sweep_analysis.py --num_generate 10 --top_n 3
+python scripts/runners/run_sweep_analysis.py --num_generate 10 --top_n 3
 
 # Run evolutionary scenario generation with parallel processing
-python run_evolutionary_generator.py --pop_size 20 --generations 5 --eval_runs 3
+python scripts/runners/run_evolutionary_generator.py --pop_size 20 --generations 5 --eval_runs 3
 
 # Analyze evolutionary results
-python -m analysis.evolution_visualizer --output evolution_report
+# (visualization script removed - view data in the `evolution_analysis` directory)
 
 # Lint code
 black npdl/

--- a/docs/SCENARIO_GENERATION.md
+++ b/docs/SCENARIO_GENERATION.md
@@ -21,7 +21,7 @@ This approach helps you efficiently explore the vast parameter space of Prisoner
 To run the complete workflow (generation, evaluation, selection, analysis):
 
 ```bash
-python run_sweep_analysis.py
+python scripts/runners/run_sweep_analysis.py
 ```
 
 This will:
@@ -36,12 +36,12 @@ This will:
 For more control over the process:
 
 ```bash
-python run_sweep_analysis.py --num_generate 50 --eval_runs 3 --save_runs 15 --top_n 8 --results_dir "results/my_scenario_sweep" --analysis_dir "my_analysis_results"
+python scripts/runners/run_sweep_analysis.py --num_generate 50 --eval_runs 3 --save_runs 15 --top_n 8 --results_dir "results/my_scenario_sweep" --analysis_dir "my_analysis_results"
 ```
 
 ## Components
 
-### 1. Scenario Generator (`run_scenario_generator.py`)
+### 1. Scenario Generator (`scripts/runners/run_scenario_generator.py`)
 
 This script:
 - Generates random scenarios by sampling from parameter pools
@@ -56,7 +56,7 @@ Key functions:
 - `calculate_interestingness_score()`: Computes a composite score based on multiple metrics
 - `run_scenario_generation()`: Main function that orchestrates the entire process
 
-### 2. Sweep Visualizer (`analysis/sweep_visualizer.py`)
+### 2. Sweep Visualizer (`npdl/analysis/sweep_visualizer.py`)
 
 This module:
 - Loads metadata about generated scenarios
@@ -233,7 +233,7 @@ This would require modifying the `run_scenario_generator.py` script to add mutat
 
 1. **Generate a diverse set of scenarios**:
    ```bash
-   python run_scenario_generator.py --num_generate 100 --eval_runs 3 --top_n 10
+   python scripts/runners/run_scenario_generator.py --num_generate 100 --eval_runs 3 --top_n 10
    ```
 
 2. **Examine the metadata to understand what makes scenarios interesting**:
@@ -252,7 +252,7 @@ This would require modifying the `run_scenario_generator.py` script to add mutat
 
 3. **Generate visualizations**:
    ```bash
-   python -m analysis.sweep_visualizer --metadata "results/generated_scenarios/generated_scenarios_metadata.json"
+   python -m npdl.analysis.sweep_visualizer --metadata "results/generated_scenarios/generated_scenarios_metadata.json"
    ```
 
 4. **Refine parameter pools based on findings**:
@@ -261,7 +261,7 @@ This would require modifying the `run_scenario_generator.py` script to add mutat
 
 5. **Run a more focused sweep**:
    ```bash
-   python run_sweep_analysis.py --num_generate 50 --results_dir "results/refined_sweep"
+   python scripts/runners/run_sweep_analysis.py --num_generate 50 --results_dir "results/refined_sweep"
    ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- correct script locations in README project tree and usage
- update scenario generation docs with new module paths
- remove references to missing evolution_visualizer script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_68522242bf1883339ee0ec5752b94999